### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Building Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           # 涓嬫柟鐨刵ame鏍煎紡涓猴細Docker Hub ID/鑷畾涔夐暅鍍忓悕绉?          
           name: uyehxbchds/vyivug


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore